### PR TITLE
feat: add Terms of Use acceptance backend

### DIFF
--- a/app/controllers/api/terms_acceptances_controller.rb
+++ b/app/controllers/api/terms_acceptances_controller.rb
@@ -1,0 +1,39 @@
+class Api::TermsAcceptancesController < ApplicationController
+  before_action :authenticate_user!
+
+  # GET /api/terms/acceptance
+  # Retorna a versão mais recente aceita pelo usuário (ou null se nunca aceitou).
+  def show
+    acceptance = current_user.latest_terms_acceptance
+
+    render json: {
+      accepted_terms_version: acceptance&.version,
+      accepted_at: acceptance&.accepted_at&.utc&.iso8601
+    }, status: :ok
+  end
+
+  # POST /api/terms/acceptance
+  # Body: { "version": "1.0.0" }
+  # Registra o aceite. accepted_at é definido pelo servidor; ip_address e
+  # user_agent são capturados da própria requisição. Idempotente: aceitar a
+  # mesma versão novamente apenas registra um novo evento de histórico, sem erro.
+  def create
+    version = params[:version]
+
+    if version.blank?
+      return render json: { error: "O campo 'version' é obrigatório." }, status: :unprocessable_entity
+    end
+
+    acceptance = current_user.terms_acceptances.create!(
+      version: version,
+      accepted_at: Time.current,
+      ip_address: request.remote_ip,
+      user_agent: request.user_agent
+    )
+
+    render json: {
+      accepted_terms_version: acceptance.version,
+      accepted_at: acceptance.accepted_at.utc.iso8601
+    }, status: :created
+  end
+end

--- a/app/models/terms_acceptance.rb
+++ b/app/models/terms_acceptance.rb
@@ -1,0 +1,6 @@
+class TermsAcceptance < ApplicationRecord
+  belongs_to :user
+
+  validates :version, presence: true
+  validates :accepted_at, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,15 @@ class User < ApplicationRecord
 
   has_many :decks, dependent: :destroy
   has_many :password_resets, dependent: :destroy
+  has_many :terms_acceptances, dependent: :destroy
+
+  # Última (mais recente) aceitação de termo do usuário, por accepted_at.
+  def latest_terms_acceptance
+    terms_acceptances.order(accepted_at: :desc).first
+  end
+
+  # Versão do termo mais recentemente aceita (ou nil se nunca aceitou).
+  def accepted_terms_version
+    latest_terms_acceptance&.version
+  end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,3 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :email, :full_name
+  attributes :id, :email, :full_name, :accepted_terms_version
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,9 @@ Rails.application.routes.draw do
 
     post "auth/google_oauth2/callback", to: "authentications#google_oauth2"
 
+    get "terms/acceptance", to: "terms_acceptances#show"
+    post "terms/acceptance", to: "terms_acceptances#create"
+
     resources :users, only: [ :create ]
 
     post "/login", to: "sessions#create"

--- a/db/migrate/20260601120000_create_terms_acceptances.rb
+++ b/db/migrate/20260601120000_create_terms_acceptances.rb
@@ -1,0 +1,15 @@
+class CreateTermsAcceptances < ActiveRecord::Migration[8.0]
+  def change
+    create_table :terms_acceptances do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :version, null: false
+      t.datetime :accepted_at, null: false
+      t.string :ip_address
+      t.string :user_agent
+
+      t.timestamps
+    end
+
+    add_index :terms_acceptances, [ :user_id, :version ]
+  end
+end

--- a/test/controllers/api/authentications_controller_test.rb
+++ b/test/controllers/api/authentications_controller_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class Api::AuthenticationsControllerTest < ActionDispatch::IntegrationTest
+  test "google_oauth2 callback inclui accepted_terms_version no objeto user" do
+    payload = { "email" => "google@example.com", "name" => "Google User" }
+
+    fake_validator = Minitest::Mock.new
+    fake_validator.expect(:check, payload) { |_token, _client_id| true }
+
+    GoogleIDToken::Validator.stub(:new, fake_validator) do
+      post api_auth_google_oauth2_callback_url, params: { token: "fake-id-token" }
+    end
+
+    assert_response :ok
+    body = JSON.parse(response.body)
+    assert body["user"].key?("accepted_terms_version")
+    assert_nil body["user"]["accepted_terms_version"]
+  end
+end

--- a/test/controllers/api/sessions_controller_test.rb
+++ b/test/controllers/api/sessions_controller_test.rb
@@ -1,7 +1,30 @@
 require "test_helper"
 
 class Api::SessionsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @user = User.create!(
+      full_name: "Login User",
+      email: "login@example.com",
+      password: "password"
+    )
+  end
+
+  test "login inclui accepted_terms_version no objeto user (null quando nunca aceitou)" do
+    post api_login_url, params: { email: @user.email, password: "password" }
+
+    assert_response :ok
+    body = JSON.parse(response.body)
+    assert body["user"].key?("accepted_terms_version")
+    assert_nil body["user"]["accepted_terms_version"]
+  end
+
+  test "login reflete a versão mais recente aceita no objeto user" do
+    @user.terms_acceptances.create!(version: "1.0.0", accepted_at: Time.current)
+
+    post api_login_url, params: { email: @user.email, password: "password" }
+
+    assert_response :ok
+    body = JSON.parse(response.body)
+    assert_equal "1.0.0", body["user"]["accepted_terms_version"]
+  end
 end

--- a/test/controllers/api/terms_acceptances_controller_test.rb
+++ b/test/controllers/api/terms_acceptances_controller_test.rb
@@ -1,0 +1,106 @@
+require "test_helper"
+
+class Api::TermsAcceptancesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = User.create!(
+      full_name: "Terms User",
+      email: "terms@example.com",
+      password: "password"
+    )
+  end
+
+  # ---------- POST /api/terms/acceptance ----------
+
+  test "POST registra o aceite e retorna versão e accepted_at" do
+    post api_terms_acceptance_url,
+      params: { version: "1.0.0" },
+      headers: authenticated_user(@user)
+
+    assert_response :created
+    body = JSON.parse(response.body)
+
+    assert_equal "1.0.0", body["accepted_terms_version"]
+    assert_not_nil body["accepted_at"]
+
+    acceptance = @user.terms_acceptances.last
+    assert_equal "1.0.0", acceptance.version
+  end
+
+  test "POST define accepted_at no servidor (ignora o cliente) e em UTC ISO-8601" do
+    post api_terms_acceptance_url,
+      params: { version: "1.0.0", accepted_at: "1999-01-01T00:00:00Z" },
+      headers: authenticated_user(@user)
+
+    assert_response :created
+    body = JSON.parse(response.body)
+
+    # Não confia no accepted_at enviado pelo cliente.
+    refute_equal "1999-01-01T00:00:00Z", body["accepted_at"]
+    # Formato UTC ISO-8601 terminando em Z.
+    assert_match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\z/, body["accepted_at"])
+  end
+
+  test "POST captura ip_address e user_agent da requisição" do
+    post api_terms_acceptance_url,
+      params: { version: "1.0.0" },
+      headers: authenticated_user(@user).merge("User-Agent" => "MemourizeApp/1.2.3")
+
+    assert_response :created
+    acceptance = @user.terms_acceptances.last
+    assert_equal "MemourizeApp/1.2.3", acceptance.user_agent
+    assert acceptance.ip_address.present?
+  end
+
+  test "POST é idempotente: aceitar a mesma versão duas vezes não dá erro" do
+    post api_terms_acceptance_url, params: { version: "1.0.0" }, headers: authenticated_user(@user)
+    assert_response :created
+
+    post api_terms_acceptance_url, params: { version: "1.0.0" }, headers: authenticated_user(@user)
+    assert_response :created
+
+    body = JSON.parse(response.body)
+    assert_equal "1.0.0", body["accepted_terms_version"]
+  end
+
+  test "POST retorna 422 quando version está ausente" do
+    post api_terms_acceptance_url, params: {}, headers: authenticated_user(@user)
+    assert_response :unprocessable_entity
+    assert_no_difference -> { @user.terms_acceptances.count } do
+      post api_terms_acceptance_url, params: { version: "" }, headers: authenticated_user(@user)
+    end
+    assert_response :unprocessable_entity
+  end
+
+  test "POST retorna 401 sem JWT" do
+    post api_terms_acceptance_url, params: { version: "1.0.0" }
+    assert_response :unauthorized
+  end
+
+  # ---------- GET /api/terms/acceptance ----------
+
+  test "GET retorna null quando o usuário nunca aceitou" do
+    get api_terms_acceptance_url, headers: authenticated_user(@user)
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_nil body["accepted_terms_version"]
+    assert_nil body["accepted_at"]
+  end
+
+  test "GET retorna a versão mais recente aceita (por accepted_at)" do
+    @user.terms_acceptances.create!(version: "1.0.0", accepted_at: 2.days.ago)
+    latest = @user.terms_acceptances.create!(version: "2.0.0", accepted_at: 1.hour.ago)
+
+    get api_terms_acceptance_url, headers: authenticated_user(@user)
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal "2.0.0", body["accepted_terms_version"]
+    assert_equal latest.accepted_at.utc.iso8601, body["accepted_at"]
+  end
+
+  test "GET retorna 401 sem JWT" do
+    get api_terms_acceptance_url
+    assert_response :unauthorized
+  end
+end

--- a/test/controllers/api/users_controller_test.rb
+++ b/test/controllers/api/users_controller_test.rb
@@ -1,7 +1,19 @@
 require "test_helper"
 
 class Api::UsersControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  test "cadastro inclui accepted_terms_version no objeto user (null em conta nova)" do
+    post api_users_url, params: {
+      user: {
+        full_name: "New User",
+        email: "newuser@example.com",
+        password: "password",
+        password_confirmation: "password"
+      }
+    }
+
+    assert_response :created
+    body = JSON.parse(response.body)
+    assert body["user"].key?("accepted_terms_version")
+    assert_nil body["user"]["accepted_terms_version"]
+  end
 end


### PR DESCRIPTION
Add terms_acceptances table (user_id, version, accepted_at, ip_address, user_agent) with a (user_id, version) index, plus authenticated endpoints to record and query a user's most recent accepted terms version.

- POST /api/terms/acceptance: records acceptance; accepted_at is set server-side, ip_address/user_agent captured from the request, idempotent (history rows), 422 when version is blank.
- GET /api/terms/acceptance: returns the latest accepted version/date (or null) in UTC ISO-8601.
- Include accepted_terms_version (nullable, additive) in the user object of /login, /auth/google_oauth2/callback and /users responses.

Tests cover both endpoints and the auth-payload field presence. Note: db/schema.rb regenerates on first `rails db:migrate` (no Ruby toolchain available in this environment to run the migration).