### PR TITLE
feat: intervalo de revisao em minutos e contador de cards a revisar

### DIFF
--- a/app/controllers/api/cards_controller.rb
+++ b/app/controllers/api/cards_controller.rb
@@ -34,7 +34,7 @@ class Api::CardsController < ApplicationController
   def done
     ActiveRecord::Base.transaction do
       @card.card_reviews.create!(difficulty: params[:difficulty], date: Date.today)
-      @card.update!(last_difficulty: params[:difficulty], last_view: Date.today)
+      @card.update!(last_difficulty: params[:difficulty], last_view: Time.current)
       @card.advance_definition_cursor!
     end
     head :ok

--- a/app/controllers/api/decks_controller.rb
+++ b/app/controllers/api/decks_controller.rb
@@ -4,7 +4,12 @@ class Api::DecksController < ApplicationController
 
   def index
     @decks = current_user.decks
-    render json: { data: @decks.as_json(include: :cards) }
+    render json: {
+      data: @decks.map do |deck|
+        deck.as_json(include: :cards)
+            .merge("cards_to_review" => deck.cards.ready_to_review.count)
+      end
+    }
   end
 
   def show

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -5,10 +5,14 @@ class Card < ApplicationRecord
            class_name: "CardAlternativeDefinition",
            dependent: :destroy
 
+  # DEMO: intervalo de revisão em MINUTOS (em vez de dias) para a apresentação.
+  # Para voltar ao comportamento normal, troque para "days".
+  REVIEW_INTERVAL_UNIT = "minutes".freeze
+
   scope :ready_to_review, -> {
     where(last_difficulty: nil)
       .or(where(last_view: nil))
-      .or(where("date(last_view, '+' || last_difficulty || ' days') <= ?", Date.today.to_s))
+      .or(where("datetime(last_view, '+' || last_difficulty || ' #{REVIEW_INTERVAL_UNIT}') <= datetime('now')"))
   }
 
   # Total number of "views": the original definition plus each alternative.

--- a/db/migrate/20260607120000_change_cards_last_view_to_datetime.rb
+++ b/db/migrate/20260607120000_change_cards_last_view_to_datetime.rb
@@ -1,0 +1,9 @@
+class ChangeCardsLastViewToDatetime < ActiveRecord::Migration[8.0]
+  def up
+    change_column :cards, :last_view, :datetime
+  end
+
+  def down
+    change_column :cards, :last_view, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_01_120000) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_07_120000) do
   create_table "card_alternative_definitions", force: :cascade do |t|
     t.integer "card_id", null: false
     t.text "content", null: false
@@ -33,7 +33,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_01_120000) do
     t.string "term"
     t.string "definition"
     t.integer "last_difficulty"
-    t.date "last_view"
+    t.datetime "last_view"
     t.integer "deck_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/test/controllers/api/decks_controller_test.rb
+++ b/test/controllers/api/decks_controller_test.rb
@@ -28,12 +28,11 @@ class Api::DecksControllerTest < ActionDispatch::IntegrationTest
 
   test "should show deck with ready_to_review filter" do
     deck = @user.decks.first
-    # Card ready to review (last_view was 5 days ago, last_difficulty was 2)
-    # 2 days after last_view is 3 days ago, which is <= today.
-    card1 = deck.cards.create!(term: "T1", definition: "D1", last_view: 5.days.ago, last_difficulty: 2)
-    # Card NOT ready to review (last_view was yesterday, last_difficulty was 5)
-    # 5 days after last_view is in 4 days, which is > today.
-    card2 = deck.cards.create!(term: "T2", definition: "D2", last_view: 1.day.ago, last_difficulty: 5)
+    # Intervalo de revisão está em MINUTOS (Card::REVIEW_INTERVAL_UNIT).
+    # Card ready to review: visto há 5 min, intervalo 2 min => vence há 3 min, <= agora.
+    card1 = deck.cards.create!(term: "T1", definition: "D1", last_view: 5.minutes.ago, last_difficulty: 2)
+    # Card NOT ready to review: visto há 10s, intervalo 5 min => vence em ~5 min, > agora.
+    card2 = deck.cards.create!(term: "T2", definition: "D2", last_view: 10.seconds.ago, last_difficulty: 5)
     # Card with nil last_view or last_difficulty (should now be included when filtered)
     card3 = deck.cards.create!(term: "T3", definition: "D3")
 


### PR DESCRIPTION
- ready_to_review passa a usar intervalo em MINUTOS (Card::REVIEW_INTERVAL_UNIT) com base em last_view (agora datetime); cards#done grava Time.current
- migracao last_view: date -> datetime
- decks#index retorna cards_to_review (contagem via ready_to_review)
- ajusta teste de ready_to_review para a escala de minutos